### PR TITLE
Fix crash after removing obstacles 

### DIFF
--- a/firmware/src/physics/hashtable.cpp
+++ b/firmware/src/physics/hashtable.cpp
@@ -142,7 +142,7 @@ void Hashtable::add(AnnotatedEdge* edge)
 
 void Hashtable::remove(AnnotatedEdge* edge)
 {
-    for(auto&& cellIndex : getCellIndices(*(edge->m_edge)))
+    for(auto&& cellIndex : expand(getCellIndices(*(edge->m_edge))))
     {
         auto& cell = m_cells[cellIndex];
         auto it = std::find(
@@ -152,6 +152,7 @@ void Hashtable::remove(AnnotatedEdge* edge)
         if(it != cell.end())
         {
             cell.erase(it);
+            cell.shrink_to_fit();
         }
     }
     edge->destroy();


### PR DESCRIPTION
This fixes #316 
Issues were
1. not properly removing all edges
2. not freeing storage reserved by vectors in cells. `shrink_to_fit()` frees this storage now.