### PR TITLE
Reset connection state for messages that arrive before the first ack

### DIFF
--- a/firmware/src/utils/serial.cpp
+++ b/firmware/src/utils/serial.cpp
@@ -555,6 +555,7 @@ void DPSerial::receive()
         {
             Serial.read();
         }
+        s_receiveState = NONE;
         return;
     }
 


### PR DESCRIPTION
This should fix the problem when we cannot connect after sending i.e. "createObstacle" or "sendMotor" too early. Messages will still not be queued on the device to be processed after a connection is achieved, clients should thus poll until a connection is established (after the first syn ack is sent) before sending data of their own.