### PR TITLE
fix pointing angle for upper handle; Not tested on lower handle though

### DIFF
--- a/firmware/src/hardware/panto.cpp
+++ b/firmware/src/hardware/panto.cpp
@@ -87,7 +87,6 @@ void Panto::forwardKinematics()
     m_pointingAngle =
         handleAngle +
         (encoderFlipped[c_globalHandleIndex]==1? 1 : -1)* //sign changes when encoder is flipped
-        (c_pantoIndex==0 ? -1 : 1)*
         (c_handleMountedOnRightArm==1 ?
         rightElbowTotalAngle :
         leftElbowTotalAngle);


### PR DESCRIPTION
@corinnaj @georgt99 could one of you please check if this code adaptation also fixes the lower handle's end effector direction? The encoder connector on my board is broken so on my device I can rotate as much as I want but the end effector would never rotate.