### PR TITLE
Fiona end effector fix

### DIFF
--- a/firmware/src/hardware/panto.cpp
+++ b/firmware/src/hardware/panto.cpp
@@ -86,9 +86,9 @@ void Panto::forwardKinematics()
     m_rightInnerAngle = rightElbowTotalAngle;
     m_pointingAngle =
         handleAngle +
-        (encoderFlipped[c_globalHandleIndex]==1? 1 : -1)* //sign changes when encoder is flipped
-        (c_handleMountedOnRightArm==1 ?
-        (rightElbowTotalAngle) :
+        (encoderFlipped[c_globalHandleIndex]==1? -1 : 1)* //sign changes when encoder is flipped (changed on 21/04/22, was ...? 1: -1 before)
+        (c_handleMountedOnRightArm==1 ?       
+        (rightElbowTotalAngle) : // maybe it should be -rightElbowTotalAngle? TODO: test on Doerte
         (leftElbowTotalAngle));
     
     // PERFMON_STOP("[abbi] store angles");

--- a/hardware/ember.json
+++ b/hardware/ember.json
@@ -1,180 +1,152 @@
 {
-    "firmware": "ESP32",
-    "opMinDist": 65,
-    "opMaxDist": 210,
-    "opAngle": 2.2,
-    "forceFactor": 0.0085,
-    "dummyPin": 40,
-    "usesSpi": true,
-    "forcePidFactor": [
-        0.375,
-        0,
-        0
-    ],
-    "hashtableMemory": 200000,
-    "obstacleChangesPerFrame": 1,
-    "range": {
-        "minX": -180,
-        "minY": -205,
-        "maxX": 180,
-        "maxY": 5
-    },
-    "pantos": {
-        "upper": {
-            "left": {
-                "linkage": {
-                    "innerLength": 95.07,
-                    "outerLength": 119.79,
-                    "baseX": -23.7,
-                    "baseY": 0
-                },
-                "motor": {
-                    "pwmPinForwards": 16,
-                    "pwmPinBackwards": 4,
-                    "flipped": false,
-                    "powerLimit": 0.2,
-                    "powerLimitForce": 0.6,
-                    "pidFactor": [
-                        6,
-                        0,
-                        600
-                    ]
-                },
-                "encoder": {
-                    "steps": 16384,
-                    "flipped": false,
-                    "setup": -0.5,
-                    "spiIndex": 3
-                }
-            },
-            "right": {
-                "linkage": {
-                    "innerLength": 57.71,
-                    "outerLength": 119.79,
-                    "baseX": 61.1,
-                    "baseY": 0
-                },
-                "motor": {
-                    "pwmPinForwards": 2,
-                    "pwmPinBackwards": 17,
-                    "flipped": false,
-                    "powerLimit": 0.2,
-                    "powerLimitForce": 0.6,
-                    "pidFactor": [
-                        6,
-                        0,
-                        600
-                    ]
-                },
-                "encoder": {
-                    "steps": 16384,
-                    "flipped": false,
-                    "setup": 0.001,
-                    "spiIndex": 2
-                }
-            },
-            "handle": {
-                "linkage": {
-                    "handleMount": 1
-                },
-                "motor": {
-                    "pwmPin": 25,
-                    "dirAPin": 32,
-                    "flipped": true,
-                    "powerLimit": 0.2,
-                    "powerLimitForce": 0.2,
-                    "pidFactor": [
-                        0.5,
-                        0,
-                        30
-                    ]
-                },
-                "encoder": {
-                    "aPin": 35,
-                    "bPin": 34,
-                    "steps": 136,
-                    "flipped": true,
-                    "setup": 0
-                }
-            }
+  "firmware": "ESP32",
+  "opMinDist": 65,
+  "opMaxDist": 210,
+  "opAngle": 2.2,
+  "forceFactor": 0.0085,
+  "dummyPin": 40,
+  "usesSpi": true,
+  "forcePidFactor": [0.375, 0, 0],
+  "hashtableMemory": 200000,
+  "obstacleChangesPerFrame": 1,
+  "range": {
+    "minX": -180,
+    "minY": -205,
+    "maxX": 180,
+    "maxY": 5
+  },
+  "pantos": {
+    "upper": {
+      "left": {
+        "linkage": {
+          "innerLength": 95.07,
+          "outerLength": 119.79,
+          "baseX": -23.7,
+          "baseY": 0
         },
-        "lower": {
-            "left": {
-                "linkage": {
-                    "innerLength": 57.71,
-                    "outerLength": 119.79,
-                    "baseX": -61.1,
-                    "baseY": 0
-                },
-                "motor": {
-                    "pwmPinForwards": 22,
-                    "pwmPinBackwards": 21,
-                    "flipped": false,
-                    "powerLimit": 0.2,
-                    "powerLimitForce": 0.6,
-                    "pidFactor": [
-                        6,
-                        0,
-                        600
-                    ]
-                },
-                "encoder": {
-                    "steps": 16384,
-                    "flipped": true,
-                    "setup": -0.5,
-                    "spiIndex": 0
-                }
-            },
-            "right": {
-                "linkage": {
-                    "innerLength": 95.07,
-                    "outerLength": 119.79,
-                    "baseX": 23.7,
-                    "baseY": 0
-                },
-                "motor": {
-                    "pwmPinForwards": 19,
-                    "pwmPinBackwards": 18,
-                    "flipped": false,
-                    "powerLimit": 0.2,
-                    "powerLimitForce": 0.6,
-                    "pidFactor": [
-                        6,
-                        0,
-                        600
-                    ]
-                },
-                "encoder": {
-                    "steps": 16384,
-                    "flipped": true,
-                    "setup": 0.001,
-                    "spiIndex": 1
-                }
-            },
-            "handle": {
-                "linkage": {
-                    "handleMount": 0
-                },
-                "motor": {
-                    "pwmPin": 23,
-                    "dirAPin": 26,
-                    "flipped": false,
-                    "powerLimit": 0.2,
-                    "powerLimitForce": 0.2,
-                    "pidFactor": [
-                        0.5,
-                        0,
-                        30
-                    ]
-                },
-                "encoder": {
-                    "aPin": 36,
-                    "bPin": 39,
-                    "steps": 136,
-                    "flipped": false,
-                    "setup": 0
-                }
-            }
+        "motor": {
+          "pwmPinForwards": 16,
+          "pwmPinBackwards": 4,
+          "flipped": false,
+          "powerLimit": 0.2,
+          "powerLimitForce": 0.6,
+          "pidFactor": [6, 0, 600]
+        },
+        "encoder": {
+          "steps": 16384,
+          "flipped": false,
+          "setup": -0.5,
+          "spiIndex": 3
         }
+      },
+      "right": {
+        "linkage": {
+          "innerLength": 57.71,
+          "outerLength": 119.79,
+          "baseX": 61.1,
+          "baseY": 0
+        },
+        "motor": {
+          "pwmPinForwards": 2,
+          "pwmPinBackwards": 17,
+          "flipped": false,
+          "powerLimit": 0.2,
+          "powerLimitForce": 0.6,
+          "pidFactor": [6, 0, 600]
+        },
+        "encoder": {
+          "steps": 16384,
+          "flipped": false,
+          "setup": 0.001,
+          "spiIndex": 2
+        }
+      },
+      "handle": {
+        "linkage": {
+          "handleMount": 1
+        },
+        "motor": {
+          "pwmPin": 25,
+          "dirAPin": 32,
+          "flipped": true,
+          "powerLimit": 0.2,
+          "powerLimitForce": 0.2,
+          "pidFactor": [0.5, 0, 30]
+        },
+        "encoder": {
+          "aPin": 35,
+          "bPin": 34,
+          "steps": 136,
+          "flipped": true,
+          "setup": 0
+        }
+      }
+    },
+    "lower": {
+      "left": {
+        "linkage": {
+          "innerLength": 57.71,
+          "outerLength": 119.79,
+          "baseX": -61.1,
+          "baseY": 0
+        },
+        "motor": {
+          "pwmPinForwards": 22,
+          "pwmPinBackwards": 21,
+          "flipped": false,
+          "powerLimit": 0.2,
+          "powerLimitForce": 0.6,
+          "pidFactor": [6, 0, 600]
+        },
+        "encoder": {
+          "steps": 16384,
+          "flipped": true,
+          "setup": -0.5,
+          "spiIndex": 0
+        }
+      },
+      "right": {
+        "linkage": {
+          "innerLength": 95.07,
+          "outerLength": 119.79,
+          "baseX": 23.7,
+          "baseY": 0
+        },
+        "motor": {
+          "pwmPinForwards": 19,
+          "pwmPinBackwards": 18,
+          "flipped": false,
+          "powerLimit": 0.2,
+          "powerLimitForce": 0.6,
+          "pidFactor": [6, 0, 600]
+        },
+        "encoder": {
+          "steps": 16384,
+          "flipped": true,
+          "setup": 0.001,
+          "spiIndex": 1
+        }
+      },
+      "handle": {
+        "linkage": {
+          "handleMount": 0
+        },
+        "motor": {
+          "pwmPin": 23,
+          "dirAPin": 26,
+          "flipped": false,
+          "powerLimit": 0.2,
+          "powerLimitForce": 0.2,
+          "pidFactor": [0.5, 0, 30]
+        },
+        "encoder": {
+          "aPin": 36,
+          "bPin": 39,
+          "steps": 260,
+          "flipped": false,
+          "setup": 0
+        }
+      }
     }
+  }
 }


### PR DESCRIPTION
Before merging, test on Doerte (and on Fiona/Ember with a lower end effector) if the rotation still works. 
If not, try the following: 
- [ ] change the flipped bit for the end effector motor and encoder for the upper handle in the ember config
- [ ] revert the changes in the panto.cpp and subtract the rightTotalElbow if the handle is mounted on the right arm from the pointingAngle