### PR TITLE
Use PSRAM

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -12,11 +12,15 @@ platform = espressif32
 framework = arduino
 board = esp32dev
 build_flags =
+    -DCORE_DEBUG_LEVEL=5
     -I${protocol.include_dir}
     -D_GLIBCXX_USE_C99
     -DENABLE_FPS
     -g
     -frtti
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -nostdlib
     #-DENABLE_CRASHDUMP
     #-DENABLE_PERFMON
     # use this while debugging

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,16 +1,31 @@
 #include <utility>
-
+#include <Arduino.h> //do we need this?
 #include "ioMain.hpp"
 #include "physicsMain.hpp"
 #include "tasks/taskRegistry.hpp"
 #include "utils/serial.hpp"
 
+#include <cstdlib>
+#include <new>
+
+void *operator new(size_t size) noexcept { return ps_malloc(size); }
+void operator delete(void *p) noexcept { free(p); }
+void *operator new[](size_t size) noexcept { return operator new(size); }
+void operator delete[](void *p) noexcept { operator delete(p); }
+void *operator new(size_t size, std::nothrow_t) noexcept { return operator new(size); }
+void operator delete(void *p, std::nothrow_t) noexcept { operator delete(p); }
+void *operator new[](size_t size, std::nothrow_t) noexcept { return operator new(size); }
+void operator delete[](void *p, std::nothrow_t) noexcept { operator delete(p); }
+
+
 void setup()
 {
+    psramInit();
+    Serial.begin(115200);
+    bool ramFound = psramInit();
+    log_d("Ram found %d", ramFound);
     DPSerial::init();
-
     DPSerial::sendInstantDebugLog("========== START ==========");
-
     Tasks.emplace(
         std::piecewise_construct,
         std::forward_as_tuple("I/O"), 

--- a/utils/serial/src/cppLib/lib.cpp
+++ b/utils/serial/src/cppLib/lib.cpp
@@ -26,6 +26,7 @@ uint64_t CppLib::open(char *port)
         return 0;
     }
     logString("Open successfull");
+    // logString("Free heap: %i of %i (%.3f %%). Largest block: %i", ESP.getFreeHeap(), ESP.getHeapSize(), 100*ESP.getFreeHeap()/(float)ESP.getHeapSize(), ESP.getMaxAllocHeap());
     return (uint64_t)s_handle;
 }
 
@@ -40,7 +41,7 @@ void CppLib::close()
 }
 
 void CppLib::poll()
-{
+{ 
     bool receivedSync = false;
     bool receivedHeartbeat = false;
     bool receivedPosition = false;
@@ -50,6 +51,7 @@ void CppLib::poll()
 
     while (s_receiveQueue.size() > 0)
     {
+        logString("Received some data....");
         auto packet = s_receiveQueue.front();
         s_receiveQueue.pop();
 

--- a/utils/serial/src/serial/shared.cpp
+++ b/utils/serial/src/serial/shared.cpp
@@ -248,6 +248,7 @@ bool DPSerial::readHeader()
 
 bool DPSerial::readPayload()
 {
+    logString("Received some payload");
     const uint16_t size = s_receiveHeader.PayloadSize;
     std::vector<char> received;
     received.reserve(size);


### PR DESCRIPTION
Using new ESP32 (WROVER) which comes with 4 MB PSRAM.

Overrides the new operator of the std lib to always allocate memory on the PSRAM as it's way bigger (4MB vs 320KB internal). 