### PR TITLE
Slightly adjusted the comment in platformio.ini clarifying port-selection

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -37,5 +37,7 @@ lib_deps =
 # If this doesn't work, comment it out and try again.
 # You can also find all available ports with `pio device list`
 # or in the "Devices" tab in PlatformIO Home.
+# In both cases, the description of the port your DualPanto is connected to
+# will contain something like "CP2102 USB to UART Bridge Controller"
 # On Windows comment out this line‚
 upload_port = /dev/cu.SLAB_USBtoUART

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -33,6 +33,9 @@ lib_deps =
     https://github.com/PaulStoffregen/Encoder.git
     tomstewart89/BasicLinearAlgebra@^3.2
 
-# On OSX you need to use the following USB port
-# On Windows outcomment this line‚
+# On OSX on some machines you need to use the following USB port.
+# If this doesn't work, comment it out and try again.
+# You can also find all available ports with `pio device list`
+# or in the "Devices" tab in PlatformIO Home.
+# On Windows comment out this line‚
 upload_port = /dev/cu.SLAB_USBtoUART


### PR DESCRIPTION
The port set in the config works for Idris but does not work for me (he is on M1 Max, I'm on M2 Max).
I adjusted the comment so avoid confusing less experienced students working on this on newer Macs and also added how to find the port using commandline or by checking PlatformIO.