### PR TITLE
Add battery voltage to state update

### DIFF
--- a/documentation/protocol/protocol.md
+++ b/documentation/protocol/protocol.md
@@ -35,7 +35,7 @@ The available values for messages from the hardware to the framework are:
   - [0x05 Invalid Packet ID](#0x05-Invalid-packet-id) - Informs the framework of an unexpected packet ID.
   - [0x06 Invalid Data](#0x06-Invalid-data) - Informs the packet of unexpected bytes in the receive buffer.
 - 0x10 to 0x1F - Data messages
-  - [0x10 Position](#0x10-Position) - This message contains the current positions of the handles, as well as the god objects' positions.
+  - [0x10 State](#0x10-State) - This message contains the current positions of the handles, the god objects' positions and the battery voltage.
 - 0x20 to 0x2F - Auxiliary messages
   - [0x20 Debug log](#0x20-Debug-log) - This message contains a user-defined string that is meant as a debug log.
 
@@ -168,16 +168,16 @@ Example message:
 ```
 
 
-### 0x10 Position
+### 0x10 State
 
-The message contains - in this order - the x position, the y position and the rotation of a handle, each encoded as a 32 bit float, followed by the x and y position of the god object. This is repeated for each handle.
+The message contains - in this order - the x position, the y position and the rotation of a handle, each encoded as a 32 bit float, followed by the x and y position of the god object. After the values for all handles a single float with the measured battery voltage follows.
 
 Example message for two handles:
 ```
 4450     // magic number
-10       // message type: position
+10       // message type: state
 00       // packet ID: not utilized
-0028     // payload length: 2 handles, 5 values each, 4 bytes each - 2*5*4 = 40 = 0x28
+002C     // payload length: 2 handles, 5 values each, plus one battery value - 44 bytes = 0x2C
 FFFFFFFF // x position of first handle
 FFFFFFFF // y position of first handle
 FFFFFFFF // rotation of first handle
@@ -188,6 +188,7 @@ FFFFFFFF // y position of second handle
 FFFFFFFF // rotation of second handle
 FFFFFFFF // x position of second handle's god object
 FFFFFFFF // y position of second handle's god object
+FFFFFFFF // battery voltage of the device
 ```
 
 ### 0x20 Debug log

--- a/firmware/include/hardware/panto.hpp
+++ b/firmware/include/hardware/panto.hpp
@@ -127,6 +127,8 @@ public:
     void setInTransition(bool inTransition);
     bool getIsFrozen();
     void setIsFrozen(bool isFrozen);
+    float getBatteryVoltage();
 };
 
 extern std::vector<Panto> pantos;
+extern float batteryVoltage;

--- a/firmware/include/utils/serial.hpp
+++ b/firmware/include/utils/serial.hpp
@@ -105,7 +105,7 @@ public:
     static bool ensureConnection();
 
     // send
-    static void sendPosition();
+    static void sendState();
     static void sendTransitionEnded(uint8_t panto);
     static void sendInstantDebugLog(const char *message, ...);
     static void sendQueuedDebugLog(const char *message, ...);

--- a/firmware/src/hardware/panto.cpp
+++ b/firmware/src/hardware/panto.cpp
@@ -6,6 +6,7 @@
 #include "utils/serial.hpp"
 
 std::vector<Panto> pantos;
+float batteryVoltage = 0.0f;
 
 void Panto::forwardKinematics()
 {
@@ -334,6 +335,7 @@ void Panto::readEncoders()
 void Panto::actuateMotors()
 {
     m_batteryCharge = analogRead(27);
+    batteryVoltage = m_batteryCharge * 3.3f / 4095.0f * 5.545f;
     if (m_batteryCharge < PWM_MIN_VOLTAGE){
         DPSerial::sendQueuedDebugLog("Please charge battery. Battery charge (should be between %d and %d): %d", PWM_MIN_VOLTAGE, PWM_MAX, m_batteryCharge);
         return;
@@ -633,4 +635,8 @@ bool Panto::getIsFrozen(){
 }
 void Panto::setIsFrozen(bool isFrozen){
     m_isFrozen = isFrozen;
+}
+
+float Panto::getBatteryVoltage(){
+    return batteryVoltage;
 }

--- a/firmware/src/ioMain.cpp
+++ b/firmware/src/ioMain.cpp
@@ -26,7 +26,7 @@ void ioLoop()
     //DPSerial::sendInstantDebugLog("\n");
     if (connected && sendLimiter.step())
     {
-        DPSerial::sendPosition();
+        DPSerial::sendState();
     }
     PERFMON_STOP("[b] Send positions");
     

--- a/firmware/src/utils/serial.cpp
+++ b/firmware/src/utils/serial.cpp
@@ -591,11 +591,11 @@ bool DPSerial::ensureConnection()
 
 // send
 
-void DPSerial::sendPosition()
+void DPSerial::sendState()
 {
     portENTER_CRITICAL(&s_serialMutex);
     sendMagicNumber();
-    sendHeader(POSITION, pantoCount * 5 * 4); // five values per panto, 4 bytes each
+    sendHeader(STATE, pantoCount * 5 * 4 + 4); // five values per panto plus battery voltage
 
     for (auto i = 0; i < pantoCount; ++i)
     {
@@ -608,6 +608,7 @@ void DPSerial::sendPosition()
         sendFloat(goPos.x);
         sendFloat(goPos.y);
     }
+    sendFloat(batteryVoltage);
     portEXIT_CRITICAL(&s_serialMutex);
 };
 

--- a/utils/protocol/include/protocol/messageType.hpp
+++ b/utils/protocol/include/protocol/messageType.hpp
@@ -11,7 +11,7 @@ enum MessageType
     PACKET_ACK = 0x04,
     INVALID_PACKET_ID = 0x05,
     INVALID_DATA = 0x06,
-    POSITION = 0x10,
+    STATE = 0x10,
     DEBUG_LOG = 0x20,
     SYNC_ACK = 0x80,
     HEARTBEAT_ACK = 0x81,

--- a/utils/serial/src/cppLib/lib.cpp
+++ b/utils/serial/src/cppLib/lib.cpp
@@ -43,9 +43,9 @@ void CppLib::poll()
 {
     bool receivedSync = false;
     bool receivedHeartbeat = false;
-    bool receivedPosition = false;
+    bool receivedState = false;
     bool receivedTransition = false;
-    double positionCoords[2 * 5];
+    double stateValues[2 * 5 + 1];
     uint8_t pantoIndex;
 
     while (s_receiveQueue.size() > 0)
@@ -79,12 +79,12 @@ void CppLib::poll()
         case HEARTBEAT:
             receivedHeartbeat = true;
             break;
-        case POSITION:
-            receivedPosition = true;
+        case STATE:
+            receivedState = true;
             while (packet.payloadIndex < packet.header.PayloadSize)
             {
                 uint8_t index = packet.payloadIndex / 4;
-                positionCoords[index] = packet.receiveFloat();
+                stateValues[index] = packet.receiveFloat();
             }
             break;
         case DEBUG_LOG:
@@ -123,7 +123,7 @@ void CppLib::poll()
         }
     }
 
-    if (receivedPosition)
+    if (receivedState)
     {
         if (positionHandler == nullptr)
         {
@@ -131,7 +131,7 @@ void CppLib::poll()
         }
         else
         {
-            positionHandler((uint64_t)s_handle, positionCoords);
+            positionHandler((uint64_t)s_handle, stateValues);
         }
     }
 

--- a/utils/serial/src/node/poll.cpp
+++ b/utils/serial/src/node/poll.cpp
@@ -22,8 +22,8 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
     // only keep binary state for packages where only the newest counts
     bool receivedSync = false;
     bool receivedHeartbeat = false;
-    bool receivedPosition = false;
-    double positionCoords[2 * 5];
+    bool receivedState = false;
+    double stateValues[2 * 5 + 1];
 
     while (getAvailableByteCount(s_handle))
     {
@@ -55,12 +55,12 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
         case HEARTBEAT:
             receivedHeartbeat = true;
             break;
-        case POSITION:
-            receivedPosition = true;
+        case STATE:
+            receivedState = true;
             while (offset < s_header.PayloadSize)
             {
                 uint8_t index = offset / 4;
-                positionCoords[index] = DPSerial::receiveFloat(offset);
+                stateValues[index] = DPSerial::receiveFloat(offset);
             }
             break;
         case DEBUG_LOG:
@@ -83,7 +83,7 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
         napi_call_function(env, argv[1], argv[4], 0, NULL, NULL);
     }
 
-    if (receivedPosition)
+    if (receivedState)
     {
         napi_value result;
         napi_create_array(env, &result);
@@ -96,7 +96,7 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
 
             for (auto j = 0u; j < posArgc; ++j)
             {
-                napi_create_double(env, positionCoords[i * 5 + j], &(posArgv[j]));
+                napi_create_double(env, stateValues[i * 5 + j], &(posArgv[j]));
             }
 
             napi_value vector;
@@ -107,12 +107,16 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
 
             for (auto j = 0u; j < goArgc; ++j)
             {
-                napi_create_double(env, positionCoords[i * 5 + 3 + j], &(goArgv[j]));
+                napi_create_double(env, stateValues[i * 5 + 3 + j], &(goArgv[j]));
             }
 
             NAPI_CHECK(napi_new_instance(env, argv[2], goArgc, goArgv, &vector))
             NAPI_CHECK(napi_set_element(env, result, i * 2 + 1, vector));
         }
+
+        napi_value voltage;
+        napi_create_double(env, stateValues[2 * 5], &voltage);
+        NAPI_CHECK(napi_set_element(env, result, 4, voltage));
 
         NAPI_CHECK(napi_call_function(env, argv[1], argv[5], 1, &result, NULL));
     }

--- a/utils/serial/unity/Serial.cs
+++ b/utils/serial/unity/Serial.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public class Serial : MonoBehaviour {
     public delegate void SyncDelegate(ulong handle);
     public delegate void HeartbeatDelegate(ulong handle);
-    public delegate void PositionDelegate(ulong handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8, SizeConst = 10)] double[] positions);
+    public delegate void PositionDelegate(ulong handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8, SizeConst = 11)] double[] positions);
     public delegate void LoggingDelegate(IntPtr msg);
 
     protected ulong Handle;
@@ -45,7 +45,7 @@ public class Serial : MonoBehaviour {
         SendHeartbeatAck(handle);
     }
 
-    private static void PositionHandler(ulong handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8, SizeConst = 10)] double[] positions)
+    private static void PositionHandler(ulong handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8, SizeConst = 11)] double[] positions)
     {
         Debug.Log("Received positions: (" + positions[0] + "|" + positions[1] + ")");
         //Debug.Log("Received positions");


### PR DESCRIPTION
## Summary
- rename POSITION message to STATE
- send battery voltage from firmware once per update
- parse STATE message with single battery value in PC helpers
- document new STATE message

## Testing
- `npm run build` *(fails: platformio not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf9c7bc20832abfe92fa2d3638497