### PR TITLE
Add battery voltage to state messages

### DIFF
--- a/firmware/include/physicsMain.hpp
+++ b/firmware/include/physicsMain.hpp
@@ -4,3 +4,5 @@
 
 void physicsSetup();
 void physicsLoop();
+
+extern float batteryVoltage;

--- a/firmware/include/physicsMain.hpp
+++ b/firmware/include/physicsMain.hpp
@@ -1,8 +1,49 @@
 #pragma once
 
 #define BATTERY_PIN 27 // Pin for battery voltage measurement
+#define VOLTAGE_SAMPLES 1 // Number of samples for battery voltage averaging
+#define PWM_THRESHOLD 1 // PWM value below which we adjust voltage measurements
+#include <cstdint>
 
 void physicsSetup();
 void physicsLoop();
 
 extern float batteryVoltage;
+
+struct PwmMetrics {
+    uint16_t peakPWM = 0; // Peak PWM value
+    float peakVoltageIn = 0.0f; // Raw voltage reading from the battery
+    uint16_t voltageReadingCount = 0; // Number of voltage readings taken
+    float voltageOut = 0.0f; // Computed voltage to be used for scaling
+    void addPWMReading(const uint16_t newPeak) {
+        if (newPeak > peakPWM) {
+            peakPWM = newPeak;
+        }
+    }
+    void addVoltageReading(const float newVoltage) {
+        if (newVoltage > peakVoltageIn) {
+            peakVoltageIn = newVoltage;
+        }
+    }
+    void calculateNewAverageVoltage(const float newValue) {
+        if (newValue == 0.0f) {
+            return; // Ignore zero readings
+        }
+        const auto vRCFloat = static_cast<float>(voltageReadingCount);
+        voltageOut = (voltageOut * vRCFloat + newValue) / (vRCFloat + 1.0f);
+        voltageReadingCount = voltageReadingCount < VOLTAGE_SAMPLES ?
+                                  voltageReadingCount + 1 : VOLTAGE_SAMPLES;
+    }
+    float getCurrentVoltage(const float reading) const {
+        return voltageOut == 0.0f ? reading : voltageOut;
+    }
+    void step() {
+
+        if (peakPWM < PWM_THRESHOLD){calculateNewAverageVoltage(peakVoltageIn);}
+
+        peakPWM = 0; // Reset peak PWM after each step
+        peakVoltageIn = 0.0f; // Reset voltage reading after each step
+    }
+};
+
+extern PwmMetrics* pwmMetrics;

--- a/firmware/include/utils/serial.hpp
+++ b/firmware/include/utils/serial.hpp
@@ -105,7 +105,7 @@ public:
     static bool ensureConnection();
 
     // send
-    static void sendPosition();
+    static void sendState();
     static void sendTransitionEnded(uint8_t panto);
     static void sendInstantDebugLog(const char *message, ...);
     static void sendQueuedDebugLog(const char *message, ...);

--- a/firmware/src/hardware/panto.cpp
+++ b/firmware/src/hardware/panto.cpp
@@ -30,8 +30,10 @@ uint16_t scaleMotorPwm12bit(uint16_t pwmCmd, uint16_t battAdcInt)
     // --- Target voltage at 25 % SoC -------------------------------------
     constexpr float ref_Voltage       = 8.5f;        // 100% PWM is this much (tweak this)
     const auto battAdc = static_cast<float>(battAdcInt);
-    const float vBatt = kSlope * battAdc + kIntercept;
-    batteryVoltage = vBatt;
+    float vBatt = kSlope * battAdc + kIntercept;
+    pwmMetrics->addPWMReading(pwmCmd);
+    pwmMetrics->addVoltageReading(vBatt);
+    vBatt = pwmMetrics->getCurrentVoltage(vBatt);
     if (vBatt < 11.0f) {
         return 0;
     }
@@ -498,7 +500,7 @@ Panto::Panto(uint8_t pantoIndex)
 
 
 
-    pinMode(BATTERY_PIN, ANALOG);
+    pinMode(BATTERY_PIN, ADC_11db);
     for (auto localIndex = 0; localIndex < c_dofCount; ++localIndex)
     {
         const auto globalIndex = c_globalIndexOffset + localIndex;

--- a/firmware/src/hardware/panto.cpp
+++ b/firmware/src/hardware/panto.cpp
@@ -31,6 +31,7 @@ uint16_t scaleMotorPwm12bit(uint16_t pwmCmd, uint16_t battAdcInt)
     constexpr float ref_Voltage       = 8.5f;        // 100% PWM is this much (tweak this)
     const auto battAdc = static_cast<float>(battAdcInt);
     const float vBatt = kSlope * battAdc + kIntercept;
+    batteryVoltage = vBatt;
     if (vBatt < 11.0f) {
         return 0;
     }

--- a/firmware/src/hardware/panto.cpp
+++ b/firmware/src/hardware/panto.cpp
@@ -28,7 +28,7 @@ uint16_t scaleMotorPwm12bit(uint16_t pwmCmd, uint16_t battAdcInt)
     constexpr float kIntercept = 0.7637567f;    // V offset
 
     // --- Target voltage at 25 % SoC -------------------------------------
-    constexpr float ref_Voltage       = 8.5f;        // 100% PWM is this much (tweak this)
+    constexpr float ref_Voltage       = 8.7f;        // 100% PWM is this much (tweak this)
     const auto battAdc = static_cast<float>(battAdcInt);
     float vBatt = kSlope * battAdc + kIntercept;
     pwmMetrics->addPWMReading(pwmCmd);

--- a/firmware/src/ioMain.cpp
+++ b/firmware/src/ioMain.cpp
@@ -21,14 +21,14 @@ void ioLoop()
     auto connected = DPSerial::ensureConnection();
     PERFMON_STOP("[a] Receive serial");
 
-    PERFMON_START("[b] Send positions");
+    PERFMON_START("[b] Send state");
     //DPSerial::sendDebugData();
     //DPSerial::sendInstantDebugLog("\n");
     if (connected && sendLimiter.step())
     {
-        DPSerial::sendPosition();
+        DPSerial::sendState();
     }
-    PERFMON_STOP("[b] Send positions");
+    PERFMON_STOP("[b] Send state");
     
     PERFMON_START("[c] Send debug logs");
     if (connected)

--- a/firmware/src/physics/godObject.cpp
+++ b/firmware/src/physics/godObject.cpp
@@ -346,40 +346,28 @@ Vector2D GodObject::checkCollisions(Vector2D targetPoint, Vector2D currentPositi
 
             if (m_tethered) {
                 // if the movement is tethered the targetPoint can not be further away from the current position than the outer tether radius
-                // tethered just means we cannot move further than the outer tether radius bc we're locked/moving controlled externally
                 const Vector2D movementVector = targetPoint - currentPosition;
                 double movementLength = min(m_tetherOuterRadius, movementVector.length());
                 targetPoint = currentPosition + (movementVector.normalize() * movementLength);
             }
 
-            // 1) Compute edgeDir = (edgeSecond − edgeFirst).
-            //    Since we stored: closestEdgeFirstMinusSecond = (edgeFirst − edgeSecond),
-            //    flipping it yields (edgeSecond − edgeFirst):
-            Vector2D edgeDir = closestEdgeFirstMinusSecond * -1.0f;
+            auto perpendicular = Vector2D(
+                -closestEdgeFirstMinusSecond.y,
+                closestEdgeFirstMinusSecond.x);
+            auto resolveRatio =
+                -Vector2D::determinant(
+                    closestEdgeFirstMinusSecond,
+                    closestEdgeFirst - targetPoint) /
+                Vector2D::determinant(
+                    closestEdgeFirstMinusSecond,
+                    perpendicular);
+            auto resolveVec = perpendicular * resolveRatio;
+            auto resolveLength = resolveVec.length();
+            // c_resolveDistance is super small --> we need to add a tiny padding between the godobject and the edge so that it's not getting stuck in the edge
+            targetPoint = targetPoint - (resolveVec * ((resolveLength + c_resolveDistance) / resolveLength));
 
-            // 2) Rotate by +90° to get a raw normal:
-            Vector2D rawNormal(-edgeDir.y, edgeDir.x);
 
-            // 3) Normalize to unit length:
-            Vector2D normal = rawNormal.normalize();
-
-            // 4) Ensure it points outward. Compute
-            //    checkDot = (currentPosition − closestEdgeFirst) · normal
-            Vector2D fromEdgeToGO = currentPosition - closestEdgeFirst;
-            float checkDot = fromEdgeToGO.x * normal.x + fromEdgeToGO.y * normal.y;
-            if (checkDot > 0.0f) {
-                // flip if it points inward:
-                normal = normal * -1.0f;
-            }
-
-            // 5) Compute penetration = (targetPoint − closestEdgeFirst) · normal
-            Vector2D fromEdgeToTarget = targetPoint - closestEdgeFirst;
-            float penetration = fromEdgeToTarget.x * normal.x + fromEdgeToTarget.y * normal.y;
-
-            // 6) Push targetPoint back onto (or just outside) the wall:
-            targetPoint = targetPoint - normal * (penetration + c_resolveDistance);
-
-            // Re‐query for any additional collisions using the adjusted targetPoint:
+            // check for the new point if there is another collision with any other edge
             m_possibleCollisions->clear();
             hashtable().getPossibleCollisions(
                 Edge(currentPosition, targetPoint), m_possibleCollisions);

--- a/firmware/src/physics/godObject.cpp
+++ b/firmware/src/physics/godObject.cpp
@@ -289,7 +289,7 @@ Vector2D GodObject::checkCollisions(Vector2D targetPoint, Vector2D currentPositi
 
         if (posMinusTarget == Vector2D(0, 0))
         {
-            return targetPoint;
+            return targetPoint; // redundant, we already check this in 261
         }
 
         for (auto&& indexedEdge : *m_possibleCollisions)
@@ -303,18 +303,20 @@ Vector2D GodObject::checkCollisions(Vector2D targetPoint, Vector2D currentPositi
 
             auto movementRatio =
                 -Vector2D::determinant(firstMinusSecond, firstMinusPos) /
-                divisor;
+                divisor; // this is the ratio of the movement vector that is inside the edge vector
             if (movementRatio < 0 || movementRatio > 1)
             {
                 continue;
             }
 
             auto edgeRatio =
-                Vector2D::determinant(firstMinusPos, posMinusTarget) / divisor;
+                Vector2D::determinant(firstMinusPos, posMinusTarget) / divisor; // this is the ratio of the edge vector that is inside the movement vector
             if (edgeRatio < 0 || edgeRatio > 1)
             {
                 continue;
             }
+
+            // ratios are completely irrelevant for collision calculation, were just checking if movement and edge are indeed intersecting or not
 
             // we have a collision!
             if (!foundCollision || movementRatio < shortestMovementRatio) // I think the second condition never gets called because the movementRatio loop
@@ -346,28 +348,40 @@ Vector2D GodObject::checkCollisions(Vector2D targetPoint, Vector2D currentPositi
 
             if (m_tethered) {
                 // if the movement is tethered the targetPoint can not be further away from the current position than the outer tether radius
+                // tethered just means we cannot move further than the outer tether radius bc we're locked/moving controlled externally
                 const Vector2D movementVector = targetPoint - currentPosition;
                 double movementLength = min(m_tetherOuterRadius, movementVector.length());
                 targetPoint = currentPosition + (movementVector.normalize() * movementLength);
             }
 
-            auto perpendicular = Vector2D(
-                -closestEdgeFirstMinusSecond.y,
-                closestEdgeFirstMinusSecond.x);
-            auto resolveRatio =
-                -Vector2D::determinant(
-                    closestEdgeFirstMinusSecond,
-                    closestEdgeFirst - targetPoint) /
-                Vector2D::determinant(
-                    closestEdgeFirstMinusSecond,
-                    perpendicular);
-            auto resolveVec = perpendicular * resolveRatio;
-            auto resolveLength = resolveVec.length();
-            // c_resolveDistance is super small --> we need to add a tiny padding between the godobject and the edge so that it's not getting stuck in the edge
-            targetPoint = targetPoint - (resolveVec * ((resolveLength + c_resolveDistance) / resolveLength));
+            // 1) Compute edgeDir = (edgeSecond − edgeFirst).
+            //    Since we stored: closestEdgeFirstMinusSecond = (edgeFirst − edgeSecond),
+            //    flipping it yields (edgeSecond − edgeFirst):
+            Vector2D edgeDir = closestEdgeFirstMinusSecond * -1.0f;
 
+            // 2) Rotate by +90° to get a raw normal:
+            Vector2D rawNormal(-edgeDir.y, edgeDir.x);
 
-            // check for the new point if there is another collision with any other edge
+            // 3) Normalize to unit length:
+            Vector2D normal = rawNormal.normalize();
+
+            // 4) Ensure it points outward. Compute
+            //    checkDot = (currentPosition − closestEdgeFirst) · normal
+            Vector2D fromEdgeToGO = currentPosition - closestEdgeFirst;
+            float checkDot = fromEdgeToGO.x * normal.x + fromEdgeToGO.y * normal.y;
+            if (checkDot > 0.0f) {
+                // flip if it points inward:
+                normal = normal * -1.0f;
+            }
+
+            // 5) Compute penetration = (targetPoint − closestEdgeFirst) · normal
+            Vector2D fromEdgeToTarget = targetPoint - closestEdgeFirst;
+            float penetration = fromEdgeToTarget.x * normal.x + fromEdgeToTarget.y * normal.y;
+
+            // 6) Push targetPoint back onto (or just outside) the wall:
+            targetPoint = targetPoint - normal * (penetration + c_resolveDistance);
+
+            // Re‐query for any additional collisions using the adjusted targetPoint:
             m_possibleCollisions->clear();
             hashtable().getPossibleCollisions(
                 Edge(currentPosition, targetPoint), m_possibleCollisions);

--- a/firmware/src/physicsMain.cpp
+++ b/firmware/src/physicsMain.cpp
@@ -15,6 +15,8 @@ FramerateLimiter spiErrorLimiter = FramerateLimiter::fromSeconds(1);
 SPIEncoderChain* spi;
 #endif
 
+float batteryVoltage = 0.0f;
+
 void physicsSetup()
 {
     #ifdef LINKAGE_ENCODER_USE_SPI

--- a/firmware/src/physicsMain.cpp
+++ b/firmware/src/physicsMain.cpp
@@ -99,7 +99,7 @@ void physicsLoop()
         pantoPhysics[i].step();
     }
     PERFMON_STOP("[b] Calculate physics");
-
+    pwmMetrics->step();// Moved from serial to avoid race-conditions
     PERFMON_START("[c] Actuate motors");
     for (auto i = 0; i < pantoCount; ++i)
     {

--- a/firmware/src/physicsMain.cpp
+++ b/firmware/src/physicsMain.cpp
@@ -16,6 +16,8 @@ SPIEncoderChain* spi;
 #endif
 
 float batteryVoltage = 0.0f;
+PwmMetrics* pwmMetrics = new PwmMetrics();
+
 
 void physicsSetup()
 {
@@ -78,7 +80,6 @@ void physicsLoop()
     spi->update();
     #endif
     // PERFMON_STOP("[aa] Query SPI");
-
     // PERFMON_START("[ab] Calculation loop");
     for (auto i = 0; i < pantoCount; ++i)
     {

--- a/firmware/src/utils/serial.cpp
+++ b/firmware/src/utils/serial.cpp
@@ -629,11 +629,11 @@ bool DPSerial::ensureConnection()
 
 // send
 
-void DPSerial::sendPosition()
+void DPSerial::sendState()
 {
     portENTER_CRITICAL(&s_serialMutex);
     sendMagicNumber();
-    sendHeader(POSITION, pantoCount * 5 * 4); // five values per panto, 4 bytes each
+    sendHeader(STATE, pantoCount * 5 * 4 + 4); // five values per panto, plus battery
 
     for (auto i = 0; i < pantoCount; ++i)
     {
@@ -646,6 +646,7 @@ void DPSerial::sendPosition()
         sendFloat(goPos.x);
         sendFloat(goPos.y);
     }
+    sendFloat(batteryVoltage);
     portEXIT_CRITICAL(&s_serialMutex);
 };
 

--- a/firmware/src/utils/serial.cpp
+++ b/firmware/src/utils/serial.cpp
@@ -605,7 +605,6 @@ bool DPSerial::ensureConnection()
 
 void DPSerial::sendState()
 {
-    pwmMetrics->step();
     portENTER_CRITICAL(&s_serialMutex);
     sendMagicNumber();
     sendHeader(STATE, pantoCount * 5 * 4 + 4); // five values per panto, plus battery

--- a/firmware/src/utils/serial.cpp
+++ b/firmware/src/utils/serial.cpp
@@ -7,32 +7,6 @@
 #include "physics/pantoPhysics.hpp"
 #include "utils/vector.hpp"
 
-uint16_t scaleMotorPwm12bitDEBUG(uint16_t pwmCmd, uint16_t battAdcInt)
-{
-    // --- ADC → Voltage (linear fit from your CSV) -----------------------
-    constexpr float kSlope     = 0.00454755f;   // V per ADC count
-    constexpr float kIntercept = 0.7637567f;    // V offset
-
-    // --- Target voltage at 25 % SoC -------------------------------------
-    constexpr float ref_Voltage       = 8.0f;        // output scaled so that it'd be at this voltage
-    const auto battAdc = static_cast<float>(battAdcInt);
-    const float vBatt = kSlope * battAdc + kIntercept;
-    if (vBatt < 11.0f) {
-        return 0;
-    }
-
-    float scale = ref_Voltage / vBatt;
-    if (scale > 1.0f) scale = 1.0f;
-
-    // 12-bit range is 4096 discrete steps → multiply by 4095
-    constexpr float kPwmMax = 4095.0f;
-    uint32_t pwmScaled = static_cast<uint32_t>(pwmCmd * scale + 0.5f);
-
-    // Safety clamp in case the caller passed something out of bounds
-    if (pwmScaled > kPwmMax) pwmScaled = kPwmMax;
-
-    return static_cast<uint16_t>(pwmScaled);
-}
 
 bool DPSerial::s_rxBufferCritical = false;
 Header DPSerial::s_header = Header();
@@ -631,6 +605,7 @@ bool DPSerial::ensureConnection()
 
 void DPSerial::sendState()
 {
+    pwmMetrics->step();
     portENTER_CRITICAL(&s_serialMutex);
     sendMagicNumber();
     sendHeader(STATE, pantoCount * 5 * 4 + 4); // five values per panto, plus battery
@@ -646,7 +621,7 @@ void DPSerial::sendState()
         sendFloat(goPos.x);
         sendFloat(goPos.y);
     }
-    sendFloat(batteryVoltage);
+    sendFloat(pwmMetrics->getCurrentVoltage(12.6));
     portEXIT_CRITICAL(&s_serialMutex);
 };
 
@@ -719,7 +694,7 @@ void DPSerial::sendDebugData()
     constexpr float kSlope     = 0.00454755f;   // V per ADC count
     constexpr float kIntercept = 0.7637567f;    // V offset
     auto vBatt = kSlope * a + kIntercept;        // volts
-    auto converted = scaleMotorPwm12bitDEBUG(4095, a);
+    auto converted = 0;
     sendInstantDebugLog(
         "[battery] %+08.3f | %d | %+08.3f [ang/1] %+08.3f | %+08.3f | %+08.3f [pos/0] %+08.3f | %+08.3f | %+08.3f [pos/1] %+08.3f | %+08.3f | %+08.3f",
         vBatt,

--- a/utils/protocol/include/protocol/messageType.hpp
+++ b/utils/protocol/include/protocol/messageType.hpp
@@ -11,7 +11,7 @@ enum MessageType
     PACKET_ACK = 0x04,
     INVALID_PACKET_ID = 0x05,
     INVALID_DATA = 0x06,
-    POSITION = 0x10,
+    STATE = 0x10,
     DEBUG_LOG = 0x20,
     SYNC_ACK = 0x80,
     HEARTBEAT_ACK = 0x81,

--- a/utils/protocol/include/protocol/protocol.hpp
+++ b/utils/protocol/include/protocol/protocol.hpp
@@ -10,7 +10,7 @@ class DPProtocol
 {
 protected:
     // revision
-    static const uint32_t c_revision = 6;
+    static const uint32_t c_revision = 7;
 
     // connection info
     static const uint32_t c_baudRate = 115200;

--- a/utils/serial/src/cppLib/lib.cpp
+++ b/utils/serial/src/cppLib/lib.cpp
@@ -43,9 +43,9 @@ void CppLib::poll()
 {
     bool receivedSync = false;
     bool receivedHeartbeat = false;
-    bool receivedPosition = false;
+    bool receivedState = false;
     bool receivedTransition = false;
-    double positionCoords[2 * 5];
+    double positionCoords[2 * 5 + 1];
     uint8_t pantoIndex;
 
     while (s_receiveQueue.size() > 0)
@@ -79,8 +79,8 @@ void CppLib::poll()
         case HEARTBEAT:
             receivedHeartbeat = true;
             break;
-        case POSITION:
-            receivedPosition = true;
+        case STATE:
+            receivedState = true;
             while (packet.payloadIndex < packet.header.PayloadSize)
             {
                 uint8_t index = packet.payloadIndex / 4;
@@ -123,11 +123,11 @@ void CppLib::poll()
         }
     }
 
-    if (receivedPosition)
+    if (receivedState)
     {
         if (positionHandler == nullptr)
         {
-            logString("Received position, but handler not set up");
+            logString("Received state, but handler not set up");
         }
         else
         {

--- a/utils/serial/src/node/poll.cpp
+++ b/utils/serial/src/node/poll.cpp
@@ -22,8 +22,8 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
     // only keep binary state for packages where only the newest counts
     bool receivedSync = false;
     bool receivedHeartbeat = false;
-    bool receivedPosition = false;
-    double positionCoords[2 * 5];
+    bool receivedState = false;
+    double positionCoords[2 * 5 + 1];
 
     while (getAvailableByteCount(s_handle))
     {
@@ -55,8 +55,8 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
         case HEARTBEAT:
             receivedHeartbeat = true;
             break;
-        case POSITION:
-            receivedPosition = true;
+        case STATE:
+            receivedState = true;
             while (offset < s_header.PayloadSize)
             {
                 uint8_t index = offset / 4;
@@ -83,7 +83,7 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
         napi_call_function(env, argv[1], argv[4], 0, NULL, NULL);
     }
 
-    if (receivedPosition)
+    if (receivedState)
     {
         napi_value result;
         napi_create_array(env, &result);
@@ -113,6 +113,10 @@ napi_value Node::poll(napi_env env, napi_callback_info info)
             NAPI_CHECK(napi_new_instance(env, argv[2], goArgc, goArgv, &vector))
             NAPI_CHECK(napi_set_element(env, result, i * 2 + 1, vector));
         }
+
+        napi_value battVal;
+        napi_create_double(env, positionCoords[10], &battVal);
+        NAPI_CHECK(napi_set_element(env, result, 4, battVal));
 
         NAPI_CHECK(napi_call_function(env, argv[1], argv[5], 1, &result, NULL));
     }


### PR DESCRIPTION
## Summary
- record battery voltage in `scaleMotorPwm12bit`
- expose `batteryVoltage` globally
- rename `sendPosition` to `sendState` and include voltage
- update message type and host libraries to handle new state packet
- bump protocol revision

## Testing
- `npm install --ignore-scripts`
- `npm run build` *(fails: `/root/.platformio/penv/bin/platformio: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d0561352c832a92d70915067e2329