### PR TITLE
Native serial crash fix: worker self-join on EOF and unlocked packet queues

### DIFF
--- a/utils/serial/include/serial.hpp
+++ b/utils/serial/include/serial.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <queue>
 #include <thread>
+#include <mutex>
 
 #include <protocol/header.hpp>
 #include <protocol/messageType.hpp>
@@ -43,6 +44,11 @@ protected:
     static std::queue<Packet> s_lowPrioSendQueue;
     static std::queue<Packet> s_receiveQueue;
 
+    // Guards the three queues above. The worker thread (processInput/processOutput)
+    // and the host thread (poll/send helpers) touch them concurrently, and
+    // std::queue is not thread safe, so every push/pop/front/swap holds this lock.
+    static std::mutex s_queueMutex;
+
     static uint8_t s_nextTrackedPacketId;
     static bool s_haveUnacknowledgedTrackedPacket;
     static Packet s_lastTrackedPacket;
@@ -66,6 +72,7 @@ protected:
 
     static bool isTracked(uint8_t t);
     static bool checkQueue(std::queue<Packet> &q);
+    static bool dequeueForSend(std::queue<Packet> &q, Packet &out);
     static void sendPacket(Packet p);
     static void sendInstantPacket(Packet p);
     static void write(const uint8_t *const data, const uint32_t length);

--- a/utils/serial/src/cppLib/lib.cpp
+++ b/utils/serial/src/cppLib/lib.cpp
@@ -2,6 +2,9 @@
 
 #include <iostream>
 #include <sstream>
+#include <mutex>
+#include <queue>
+#include <utility>
 
 #include "packet.hpp"
 
@@ -48,10 +51,19 @@ void CppLib::poll()
     double positionCoords[2 * 5];
     uint8_t pantoIndex;
 
-    while (s_receiveQueue.size() > 0)
+    // Take everything the worker thread has queued so far in one locked swap,
+    // then process it without holding the lock (the handlers below call back into
+    // Unity and may enqueue sends, which would deadlock if we still held it).
+    std::queue<Packet> pending;
     {
-        auto packet = s_receiveQueue.front();
-        s_receiveQueue.pop();
+        std::lock_guard<std::mutex> lock(s_queueMutex);
+        std::swap(pending, s_receiveQueue);
+    }
+
+    while (!pending.empty())
+    {
+        auto packet = pending.front();
+        pending.pop();
 
         if (packet.header.PayloadSize > c_maxPayloadSize)
         {

--- a/utils/serial/src/serial/shared.cpp
+++ b/utils/serial/src/serial/shared.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <mutex>
 
 #include "crashAnalyzer.hpp"
 #include "libInterface.hpp"
@@ -17,6 +18,7 @@ bool DPSerial::s_workerRunning = false;
 std::queue<Packet> DPSerial::s_highPrioSendQueue;
 std::queue<Packet> DPSerial::s_lowPrioSendQueue;
 std::queue<Packet> DPSerial::s_receiveQueue;
+std::mutex DPSerial::s_queueMutex;
 uint8_t DPSerial::s_nextTrackedPacketId = 1;
 bool DPSerial::s_haveUnacknowledgedTrackedPacket = false;
 Packet DPSerial::s_lastTrackedPacket(0, 0);
@@ -45,16 +47,19 @@ void DPSerial::stopWorker()
 
 void DPSerial::sendInstantPacket(Packet p)
 {
+    std::lock_guard<std::mutex> lock(s_queueMutex);
     s_highPrioSendQueue.push(p);
 }
 
 void DPSerial::sendPacket(Packet p)
 {
+    std::lock_guard<std::mutex> lock(s_queueMutex);
     s_lowPrioSendQueue.push(p);
 }
 
 void DPSerial::reset()
 {
+    std::lock_guard<std::mutex> lock(s_queueMutex);
     std::queue<Packet> emptyHP;
     std::swap(s_highPrioSendQueue, emptyHP);
     std::queue<Packet> emptyLP;
@@ -97,16 +102,29 @@ bool DPSerial::checkQueue(std::queue<Packet> &q)
     return !tracked || !s_haveUnacknowledgedTrackedPacket;
 }
 
+// Locked pop of the next sendable packet from q. Returns false (and leaves out
+// untouched) when the queue is empty or holds back a tracked packet. The queue
+// is shared with the host thread, so the check and the pop happen under the lock.
+bool DPSerial::dequeueForSend(std::queue<Packet> &q, Packet &out)
+{
+    std::lock_guard<std::mutex> lock(s_queueMutex);
+    if (!checkQueue(q))
+    {
+        return false;
+    }
+    out = q.front();
+    q.pop();
+    return true;
+}
+
 void DPSerial::processOutput()
 {
-    bool resend = false;
     Packet packet(255, 0);
 
     // send high prio packets (sync/heartbeat)
-    if (checkQueue(s_highPrioSendQueue))
+    if (dequeueForSend(s_highPrioSendQueue, packet))
     {
-        packet = s_highPrioSendQueue.front();
-        s_highPrioSendQueue.pop();
+        // sending the dequeued high prio packet
     }
     // otherwise, check if panto buffer is critical
     else if (!s_pantoReady)
@@ -123,10 +141,9 @@ void DPSerial::processOutput()
         packet = s_lastTrackedPacket;
     }
     // otherwise, send a low prio packet
-    else if (checkQueue(s_lowPrioSendQueue))
+    else if (dequeueForSend(s_lowPrioSendQueue, packet))
     {
-        packet = s_lowPrioSendQueue.front();
-        s_lowPrioSendQueue.pop();
+        // sending the dequeued low prio packet
     }
     // no packets, nothing to do
     else
@@ -212,7 +229,10 @@ bool DPSerial::readMagicNumber()
 bool DPSerial::readHeader()
 {
     uint8_t received[c_headerSize];
-    if (!readBytesFromSerial(received, c_headerSize))
+    // Only read once the whole header is buffered. A blocking read of a
+    // partially arrived header would time out (VTIME) and latch feof, which used
+    // to trigger a reconnect from the worker thread and crash the process.
+    if (!readBytesIfAvailable(received, c_headerSize))
     {
         return false;
     }
@@ -251,7 +271,8 @@ bool DPSerial::readPayload()
     const uint16_t size = s_receiveHeader.PayloadSize;
     std::vector<char> received;
     received.reserve(size);
-    if (!readBytesFromSerial(received.data(), size))
+    // Only read once the whole payload is buffered (see readHeader).
+    if (!readBytesIfAvailable(received.data(), size))
     {
         return false;
     }
@@ -294,8 +315,11 @@ bool DPSerial::readPayload()
         break;
     }
     default:
+    {
+        std::lock_guard<std::mutex> lock(s_queueMutex);
         s_receiveQueue.push(packet);
         break;
+    }
     }
 
     return true;

--- a/utils/serial/src/serial/unix.cpp
+++ b/utils/serial/src/serial/unix.cpp
@@ -27,15 +27,20 @@ bool DPSerial::readBytesFromSerial(void *target, uint32_t length)
     {
         if (feof(s_handle))
         {
-            std::cout
-                << "Read end of file from serial, trying to reconnect."
-                << std::endl;
-            tearDown();
-            setup(s_path);
+            // Do not tear down here. This runs on the worker thread, and
+            // tearDown() -> stopWorker() -> s_worker.join() would join the worker
+            // from within itself. Self-join throws std::system_error, which is
+            // unhandled on the worker thread and calls std::terminate, taking the
+            // whole host process down. Clear the end-of-file state and return; the
+            // host reopens the port (Close + Open) on its own thread once it
+            // notices the device stopped responding.
+            std::cout << "Read end of file from serial." << std::endl;
+            clearerr(s_handle);
         }
         else if (ferror(s_handle))
         {
             perror("Error while reading from serial");
+            clearerr(s_handle);
         }
     }
     return valid;


### PR DESCRIPTION
Native serial crash fix

Two threading bugs in the native serial library (dualpantoframework/utils/serial)
can abort the whole host process, the Unity editor or the standalone tool. They
sit below the C# and are not touched by the earlier connection freeze fixes.

The change lives in the framework repo, not here, so it is included as a patch:
native-crash-fix.patch (one commit, applies with git am). This repo only ships
the prebuilt binaries, so the fix reaches the toolkit only after the library is
rebuilt (see "Applying" below).

Bug 1: self-join on end of file aborts the process

readBytesFromSerial runs on the worker thread. On a short read it checked feof
and, if set, called tearDown(), which calls stopWorker(), which calls
s_worker.join(). Joining the worker from inside the worker throws
std::system_error (resource deadlock). Nothing catches it on the thread, so
std::terminate runs and the process aborts.

feof is reached two ways: a real disconnect (the device rebooted or was
unplugged), and, more often, a partial packet. The port is set to VMIN=0,
VTIME=1, so a header or payload that has not fully arrived within 100 ms makes
fread return short and stdio latches feof even though the device is fine.

Fix: read a header or payload only once it is fully buffered, the way
readMagicNumber already gates on getAvailableByteCount. A partial packet now
waits for the rest instead of being misread as end of file. On a genuine
disconnect, clear the stream state and return instead of tearing down from the
worker. Reconnection stays with the host (Close then Open), which is how the
toolkit already drives connect and reset.

Bug 2: the packet queues are shared without a lock

s_highPrioSendQueue, s_lowPrioSendQueue and s_receiveQueue are plain
std::queue touched from both threads with no synchronization. Concurrent push
and pop on the underlying std::deque is undefined behavior. It can corrupt the
container or drop packets, which looks like random native crashes and lost motor
or heartbeat traffic under load.

Fix: one mutex, held around every queue operation. The host drains the receive
queue with a single locked swap into a local queue, then processes that copy with
the lock released, so a handler that enqueues a send (the heartbeat ack, for
instance) cannot deadlock against the drain.

Scope

No exported function or signature changes, so existing callers keep working. The
standalone and Node read path (receivePacket) is untouched. The worker still
busy-polls when idle; that is pre-existing and out of scope.